### PR TITLE
Make testing of boards with SM1 bypass possible

### DIFF
--- a/sp1/sp1.asm
+++ b/sp1/sp1.asm
@@ -83,6 +83,12 @@ automatic_tests:
 		btst	#5, REG_P1CNT
 		beq	.skip_slot_switch		; skip slot switch if P1 "B" is pressed
 
+		btst	#6, REG_P1CNT
+		bne .no_bypass
+		bsr	z80_slot_switch_bypass_sm1		; slot switch but no come back to sm1 if P1 "C" is pressed
+		bra .skip_slot_switch
+
+    .no_bypass:
 		bsr	z80_slot_switch
 
 	.skip_slot_switch:

--- a/sp1/z80.asm
+++ b/sp1/z80.asm
@@ -6,6 +6,7 @@
 
 	global auto_z80_tests
 	global z80_slot_switch
+	global z80_slot_switch_bypass_sm1
 
 	section text
 
@@ -31,6 +32,8 @@ auto_z80_tests:
 z80_slot_switch:
 
 		bset.b	#Z80_TEST_FLAG_SLOT_SWITCH, z80_test_flags
+
+z80_slot_switch_bypass_sm1:
 
 		lea	XY_STR_Z80_SWITCHING_M1, a0
 		RSUB	print_xy_string_struct_clear
@@ -107,6 +110,8 @@ slot_switch_ignored:
 		RSUB	print_xy_string_struct_clear
 		lea	XY_STR_Z80_MV1BC_HOLD_B, a0
 		RSUB	print_xy_string_struct_clear
+		lea XY_STR_Z80_SM1_BYPASS_HOLD_C, a0
+		RSUB	print_xy_string_struct_clear
 		lea	XY_STR_Z80_PRESS_START, a0
 		RSUB	print_xy_string_struct_clear
 
@@ -135,6 +140,8 @@ slot_switch_ignored:
 		moveq	#16, d0
 		SSA3	fix_clear_line
 		moveq	#18, d0
+		SSA3	fix_clear_line
+		moveq	#19, d0
 		SSA3	fix_clear_line
 		rts
 
@@ -348,6 +355,7 @@ XY_STR_Z80_SM1_IGNORED:		XY_STRING  3,  5, "SM1/Z80 PREPARE SLOT SWITCH IGNORED"
 XY_STR_Z80_SM1_RESPONSIVE:	XY_STRING  3,  7, "SM1 RESPONSE"
 XY_STR_Z80_PRESS_START:		XY_STRING  3, 16, "PRESS START TO FORCE SLOT SWITCH"
 XY_STR_Z80_MV1BC_HOLD_B:	XY_STRING  3, 18, "IF MV-1B/1C: SOFT RESET & HOLD B+D"
+XY_STR_Z80_SM1_BYPASS_HOLD_C:	XY_STRING  3, 19, "IF SM1 BYPASS: SOFT RST & HOLD C+D"
 XY_STR_Z80_TESTING_COMM_PORT:	XY_STRING  4,  5, "TESTING Z80 COMM. PORT..."
 XY_STR_Z80_COMM_NO_HELLO:	XY_STRING  4,  5, "Z80->68k COMM ISSUE (HELLO)"
 XY_STR_Z80_COMM_NO_ACK:		XY_STRING  4,  5, "Z80->68k COMM ISSUE (ACK)"


### PR DESCRIPTION
I have a MV1A slot with a defective SM1 mask ROM, causing missing sound in some games. With SM1 chip removed and a "SM1 bypass" mod installed (wiring SM1 CE pin to the Z80 wait pin), the diagnostic BIOS complains about a problem with the Z80 communication (expected), but pressing start to use the test cart M1 ROM fails, as the Z80 cannot come back to SM1 ROM at some point.

This patch enables to switch to M1 on the test cart, but do the test as if run on a MV1B without SM1 ROM.